### PR TITLE
Debug fileselector

### DIFF
--- a/NtupleProcessor/include/EventAnalyzer.hh
+++ b/NtupleProcessor/include/EventAnalyzer.hh
@@ -19,6 +19,7 @@
 #include "TreeStructures.hh"
 #include "TreeReader.hh"
 #include "TreeWriter.hh"
+#include "FileSelector.hh"
 
 class EventAnalyzer
 {
@@ -66,7 +67,8 @@ class EventAnalyzer
     TTree * _hTree_LPFO_KK;
     TTree * _hTree_LPFO_KPi;
 
-    TString       _hfilename = "rootfiles/tmp_root/output.root";
+    FileSelector  _fs;
+    TString       _hfilename;
     Tree_SSbar    _tree_lpfo;
     Tree_SSbar    _tree_lpfo_kk;
     Tree_SSbar    _tree_lpfo_kpi;

--- a/NtupleProcessor/include/EventAnalyzer.hh
+++ b/NtupleProcessor/include/EventAnalyzer.hh
@@ -52,6 +52,7 @@ class EventAnalyzer
     long entriesInNtuple  ;     // Number of events that were processed to make the Ntuple.
 
   // Fixed size dimensions of array or collections stored in the TTree if any.
+    FileSelector  _fs;
 
 
   private:
@@ -67,7 +68,6 @@ class EventAnalyzer
     TTree * _hTree_LPFO_KK;
     TTree * _hTree_LPFO_KPi;
 
-    FileSelector  _fs;
     TString       _hfilename;
     Tree_SSbar    _tree_lpfo;
     Tree_SSbar    _tree_lpfo_kk;

--- a/NtupleProcessor/include/FileSelector.hh
+++ b/NtupleProcessor/include/FileSelector.hh
@@ -9,26 +9,23 @@
 #include <TObjString.h>
 #include <map>
 
-using std::string;
-
 class FileSelector
 {
   public:
     FileSelector();
-    FileSelector(string o);
+    FileSelector(TString input);
     ~FileSelector(){}
 
-    virtual void   SetNames(string o);
-    virtual string GetOutName();
-    virtual string GetOutName_withPath();
+    void   SetNames(TString input);
+    TString GetOutName();
+    TString GetOutName_withPath();
 
   private:
-    string _full;
-    string _name_ext;
-    string _name;
-    string _suffix = ".ss.tmp.root";
+    TString _full;
+    TString _name;
+    TString _suffix = ".ss.tmp.root";
 
-    string _out_path = "rootfiles/tmp_root/";
+    TString _out_path = "rootfiles/tmp_root/";
 
 
 };

--- a/NtupleProcessor/include/FileSelector.hh
+++ b/NtupleProcessor/include/FileSelector.hh
@@ -1,24 +1,34 @@
 #ifndef GUARD_FileSelector_h
 #define GUARD_FileSelector_h
 
+#include <iostream>
+#include <string>
 #include <TString.h>
+#include <TFile.h> 
 #include <TObjArray.h>
 #include <TObjString.h>
 #include <map>
+
+using std::string;
 
 class FileSelector
 {
   public:
     FileSelector();
-    FileSelector(TString o="");
+    FileSelector(string o);
     ~FileSelector(){}
 
-  private:
-    TString _full;
-    TString _path;
-    TString _name;
-    TString _ext;
+    virtual void   SetNames(string o);
+    virtual string GetOutName();
+    virtual string GetOutName_withPath();
 
+  private:
+    string _full;
+    string _name_ext;
+    string _name;
+    string _suffix = ".ss.tmp.root";
+
+    string _out_path = "rootfiles/tmp_root/";
 
 
 };

--- a/NtupleProcessor/include/NtupleProcessor.hh
+++ b/NtupleProcessor/include/NtupleProcessor.hh
@@ -26,7 +26,6 @@ class NtupleProcessor
     int            maxEvents;      // Max number of events to run over in this ntuple
 
     TFile          *ntupleFile;
-    FileSelector    fs;
 
   private: 
 

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -27,6 +27,7 @@ EventAnalyzer::EventAnalyzer(TString o)
 : options(o)
 {
     _fs.SetNames(o.Data());
+    cout << _fs.GetOutName() << endl;
     patEventsAnalyzed = 0;
     entriesInNtuple   = 0;
 }

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -26,6 +26,7 @@ typedef unsigned int Index;
 EventAnalyzer::EventAnalyzer(TString o)
 : options(o)
 {
+    _fs.SetNames(o.Data());
     patEventsAnalyzed = 0;
     entriesInNtuple   = 0;
 }
@@ -60,6 +61,7 @@ void EventAnalyzer::InitWriteTree()
 {
 
   // Initialize Write Tree
+    _hfilename = TString(_fs.GetOutName_withPath());
     _hfile = new TFile( _hfilename, "RECREATE", _hfilename ) ;
     
     _hTree_LPFO     = new TTree( "LPFO", "tree" );

--- a/NtupleProcessor/src/FileSelector.cc
+++ b/NtupleProcessor/src/FileSelector.cc
@@ -13,11 +13,11 @@ FileSelector::FileSelector(string o)
 
 void FileSelector::SetNames(string o)
 {
+  _full     = o;
   _name_ext = _full.substr(_full.find_last_of("/") + 1);
 
   string::size_type const p(_name_ext.find_last_of('.'));
   _name = _name_ext.substr(0, p);
-  cout << _name << endl;
 }
 
 string FileSelector::GetOutName()

--- a/NtupleProcessor/src/FileSelector.cc
+++ b/NtupleProcessor/src/FileSelector.cc
@@ -1,31 +1,31 @@
 #include "FileSelector.hh"
 
 using std::cout;   using std::endl;
-using std::string;
 
 FileSelector::FileSelector() {}
 
-FileSelector::FileSelector(string o)
-:_full(o)
+FileSelector::FileSelector(TString input)
+:_full(input)
 {
-  SetNames(o);
+  SetNames(_full);
 }
 
-void FileSelector::SetNames(string o)
+void FileSelector::SetNames(TString input)
 {
-  _full     = o;
-  _name_ext = _full.substr(_full.find_last_of("/") + 1);
+  _full     = input;
+  std::string str_full = _full.Data();
+  std::string name_ext = str_full.substr(str_full.find_last_of("/") + 1);
 
-  string::size_type const p(_name_ext.find_last_of('.'));
-  _name = _name_ext.substr(0, p);
+  std::string::size_type const p(name_ext.find_last_of('.'));
+  _name = TString(name_ext.substr(0, p));
 }
 
-string FileSelector::GetOutName()
+TString FileSelector::GetOutName()
 {
   return _name + _suffix;
 }
 
-string FileSelector::GetOutName_withPath()
+TString FileSelector::GetOutName_withPath()
 {
   return _out_path + _name + _suffix;
 }

--- a/NtupleProcessor/src/FileSelector.cc
+++ b/NtupleProcessor/src/FileSelector.cc
@@ -1,18 +1,31 @@
-#include <iostream>
-#include <TString.h>
-#include <TFile.h> 
-
 #include "FileSelector.hh"
 
 using std::cout;   using std::endl;
+using std::string;
 
-FileSelector::FileSelector(){}
+FileSelector::FileSelector() {}
 
-FileSelector::FileSelector(TString o)
+FileSelector::FileSelector(string o)
 :_full(o)
 {
-  cout << _full << endl;
-
-
+  SetNames(o);
 }
 
+void FileSelector::SetNames(string o)
+{
+  _name_ext = _full.substr(_full.find_last_of("/") + 1);
+
+  string::size_type const p(_name_ext.find_last_of('.'));
+  _name = _name_ext.substr(0, p);
+  cout << _name << endl;
+}
+
+string FileSelector::GetOutName()
+{
+  return _name + _suffix;
+}
+
+string FileSelector::GetOutName_withPath()
+{
+  return _out_path + _name + _suffix;
+}

--- a/NtupleProcessor/src/NtupleProcessor.cc
+++ b/NtupleProcessor/src/NtupleProcessor.cc
@@ -26,10 +26,10 @@ NtupleProcessor::NtupleProcessor(TString o, int me)
   // TString filename = "data/" + dummy_label + ".root";
 
 
-  ntupleFile = TFile::Open(o);
-  if(!ntupleFile) cout << "NtupleProcessor: ERROR: Unable to open file " << o << endl;
+  ntupleFile = TFile::Open(options);
+  if(!ntupleFile) cout << "NtupleProcessor: ERROR: Unable to open file " << options << endl;
   TTree *ntuple   = (TTree*) ntupleFile->Get("Stats");
-  if(!ntuple) cout << "NtupleProcessor: ERROR: Unable to open ttree in " << o << endl;
+  if(!ntuple) cout << "NtupleProcessor: ERROR: Unable to open ttree in " << options << endl;
   ntuple->Process(&tIter, "");
 
 

--- a/NtupleProcessor/src/NtupleProcessor.cc
+++ b/NtupleProcessor/src/NtupleProcessor.cc
@@ -10,13 +10,11 @@ NtupleProcessor.cpp
 #include "NtupleProcessor.hh"
 
 using std::cout;   using std::endl;
+using std::string;
 
 NtupleProcessor::NtupleProcessor(TString o, int me)
-: eAnalyzer(o), tIter(eAnalyzer), options(o), maxEvents(me), fs(o)
+: eAnalyzer(o), tIter(eAnalyzer), options(o), maxEvents(me)
 {
-
-  FileSelector fss("/path/to/this.root");
-
 
   // PARAM output
     cout << "  [NtupleProcessor]\n"
@@ -24,14 +22,17 @@ NtupleProcessor::NtupleProcessor(TString o, int me)
             "    MaxEntries: " << me   << "\n"
     << endl;
 
-  TString dummy_label = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.n002.d_dstm_15162_000";
-  TString filename = "data/" + dummy_label + ".root";
+  // TString dummy_label = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.n002.d_dstm_15162_000";
+  // TString filename = "data/" + dummy_label + ".root";
 
-  ntupleFile = TFile::Open(filename);
-  if(!ntupleFile) cout << "NtupleProcessor: ERROR: Unable to open file " << filename << endl;
+
+  ntupleFile = TFile::Open(o);
+  if(!ntupleFile) cout << "NtupleProcessor: ERROR: Unable to open file " << o << endl;
   TTree *ntuple   = (TTree*) ntupleFile->Get("Stats");
-  if(!ntuple) cout << "NtupleProcessor: ERROR: Unable to open ttree in " << filename << endl;
+  if(!ntuple) cout << "NtupleProcessor: ERROR: Unable to open ttree in " << o << endl;
   ntuple->Process(&tIter, "");
+
+
 
   // Takes input options and processes appropriately
   //   Options that can be specified:

--- a/main.cc
+++ b/main.cc
@@ -17,6 +17,14 @@ using namespace std;
 // int main(int argc, char* argv[])
 int main()
 {
+
+  if (__cplusplus == 201703L) std::cout << "C++17\n";
+  else if (__cplusplus == 201402L) std::cout << "C++14\n";
+  else if (__cplusplus == 201103L) std::cout << "C++11\n";
+  else if (__cplusplus == 199711L) std::cout << "C++98\n";
+  else std::cout << "pre-standard C++\n";
+
+
   // Record the time main starts processing.
   string ts_mainBegin  = timeStamp();
   string fts_mainBegin = fileTimeStamp();
@@ -28,7 +36,8 @@ int main()
           "  Processing Begun: " << ts_mainBegin << "\n"
           "\n";
 
-  NtupleProcessor ntplproc("",-1);
+  // NtupleProcessor ntplproc(argv[1],-1);
+  NtupleProcessor ntplproc("data/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.n002.d_dstm_15162_000.root",-1);
 
   // CLOSING OUTPUT.
     string ts_mainEnd = timeStamp();


### PR DESCRIPTION
## std::string to TString
The whoe problem arose from the fact that the custom class within the TSelector contained a member with std::string type.
Apparently this function doesn't like this and spits segmentation fault at the end of the process.
While this issue was not confirmed in any other plat forms (ccin2p3 nor MacOS) it was worth while to take a look, in case there was a leakage in the memory.
The solution was to simple replace std::string type to TString.