### PR TITLE
mc_stable to pfo_pdgcheat

### DIFF
--- a/NtupleProcessor/include/PFOTools.hh
+++ b/NtupleProcessor/include/PFOTools.hh
@@ -21,10 +21,10 @@ class PFOTools
   public:
     PFOTools();
     PFOTools( MC_QQbar *ptr, TString fnac );
-    PFOTools( PFO_QQbar *ptr, TString fnac );
+    PFOTools( MC_QQbar *ptr_mc, PFO_QQbar *ptr, TString fnac );
     virtual ~PFOTools() {};
     virtual void InitializeMCTools( MC_QQbar *ptr );
-    virtual void InitializePFOTools( PFO_QQbar *ptr );
+    virtual void InitializePFOTools( MC_QQbar *ptr_mc, PFO_QQbar *ptr );
 
     enum   ChargeConfig { kSame, kOpposite };
 

--- a/NtupleProcessor/include/PFOTools.hh
+++ b/NtupleProcessor/include/PFOTools.hh
@@ -43,10 +43,11 @@ class PFOTools
   // LPFO checks
     virtual Bool_t           is_charge_config ( ChargeConfig cc );
 
-    virtual Bool_t           PFO_Quality_checks    ( PFO_Info iPFO );
+    virtual Bool_t           LPFO_Quality_checks    ( PFO_Info iPFO );
     virtual Bool_t           is_momentum           ( PFO_Info iPFO, Float_t MINP, Float_t MAXP );
     virtual Bool_t           is_tpc_hits           ( PFO_Info iPFO, Int_t MIN_TPC_HITS );
     virtual Bool_t           is_offset_small       ( PFO_Info iPFO, Int_t MAX_OFFSET );
+    virtual Bool_t           is_dEdxdist_bad       ( Float_t e_dist, Float_t mu_dist, Float_t pi_dist, Float_t k_dist, Float_t p_dist );
 
     AnalysisConfig _anCfg;
 

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -112,7 +112,7 @@ void EventAnalyzer::AnalyzeReco(Long64_t entry)
 {
   // MC, PFO Analysis
     PFOTools mct( &_mc, _config );
-    PFOTools pfot( &_pfo, _config );
+    PFOTools pfot( &_mc, &_pfo, _config );
 
     // cout << "evt: " << entry << endl;
     AnalyzeGenReco(mct,pfot);
@@ -614,10 +614,20 @@ void EventAnalyzer::PolarAngle(PFOTools pfot, PFOTools mct, Bool_t s_reco)
       _hm.h1[_hm.reco_K_qcos]->Fill( iLPFO.qcos );
       // _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * sgn( iLPFO.pfo_charge * _mc.mc_quark_charge[0] ) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
     
-      if ( iLPFO.pfo_charge < 0 ) {
-        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+      if ( _mc.mc_quark_charge[0] < 0) {
+        cout << "NO" << endl;
+        if ( iLPFO.pfo_charge < 0 ) {
+          _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+        }else{
+          _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
+        }
       }else{
-        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
+        cout << "YES " << iLPFO.pfo_charge << " " << abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) << endl;
+        if ( iLPFO.pfo_charge > 0 ) {
+          _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+        }else{
+          _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
+        }
       }
     
     }

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -613,22 +613,30 @@ void EventAnalyzer::PolarAngle(PFOTools pfot, PFOTools mct, Bool_t s_reco)
       _hm.h1[_hm.reco_K_cos]->Fill( iLPFO.cos );
       _hm.h1[_hm.reco_K_qcos]->Fill( iLPFO.qcos );
       // _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * sgn( iLPFO.pfo_charge * _mc.mc_quark_charge[0] ) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
-    
+
+      if ( iLPFO.pfo_charge < 0 ) {
+        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+      }else{
+        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
+      }
+
+      /*
       if ( _mc.mc_quark_charge[0] < 0) {
-        // cout << "NO" << endl;
+        cout << "NO" << endl;
         if ( iLPFO.pfo_charge < 0 ) {
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
         }else{
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
         }
       }else{
-        // cout << "YES " << iLPFO.pfo_charge << " " << abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) << endl;
+        cout << "YES " << iLPFO.pfo_charge << " " << abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) << endl;
         if ( iLPFO.pfo_charge > 0 ) {
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
         }else{
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
         }
       }
+      */
     
     }
     

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -613,12 +613,13 @@ void EventAnalyzer::PolarAngle(PFOTools pfot, PFOTools mct, Bool_t s_reco)
       _hm.h1[_hm.reco_K_cos]->Fill( iLPFO.cos );
       _hm.h1[_hm.reco_K_qcos]->Fill( iLPFO.qcos );
       // _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * sgn( iLPFO.pfo_charge * _mc.mc_quark_charge[0] ) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+      _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * sgn( -_mc.mc_quark_charge[0] ) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
 
-      if ( iLPFO.pfo_charge < 0 ) {
-        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
-      }else{
-        _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
-      }
+      // if ( iLPFO.pfo_charge < 0 ) {
+      //   _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
+      // }else{
+      //   _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
+      // }
 
       /*
       if ( _mc.mc_quark_charge[0] < 0) {

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -441,15 +441,6 @@ Int_t *EventAnalyzer::Gen_Reco_Stats_Stable( PFOTools mct, PFOTools pfot, Float_
     if( abs(iPFO.pfo_pdgcheat) == 321 && cos_range && p_range ) Gen_K_Collection.push_back(iPFO);
   }
 
-  // std::vector<MC_Info> Gen_K_Collection;
-  // for ( int istable=0; istable < _mc.mc_stable_n; istable++ ){
-  //   Bool_t cos_range = ( cos_min < mct.mc_stable[istable].cos && mct.mc_stable[istable].cos < cos_max );
-  //   Bool_t p_range   = p_min < mct.mc_stable[istable].p_mag;
-  //   if(abs(_mc.mc_stable_pdg[istable]) == 321 && cos_range && p_range) {
-  //     Gen_K_Collection.push_back( mct.mc_stable[istable] );
-  //   }
-  // }
-
   Int_t N_K_corr  = 0;
 
   // Float_t cos_r = 0.02;
@@ -593,7 +584,6 @@ void EventAnalyzer::Mom_Polar_Gen(PFOTools mct, PFOTools pfot)
   // Gen K
   for ( int istable=0; istable < _mc.mc_stable_n; istable++ ){
 
-    // if(abs(_mc.mc_stable_pdg[istable]) == 321) cout << "genK E: " << _mc.mc_stable_E[istable] << ", p: " << mct.mc_stable[istable].p_mag << ", px: " << _mc.mc_stable_px[istable] << ", py: " << _mc.mc_stable_py[istable] << endl;
     if(abs(_mc.mc_stable_pdg[istable]) == 321 && 20 < mct.mc_stable[istable].p_mag) {
       cnt_gen_K++;
       _hm.h2[_hm.gen_K_p_cos]->Fill(mct.mc_stable[istable].cos,mct.mc_stable[istable].p_mag);
@@ -606,23 +596,11 @@ void EventAnalyzer::Mom_Polar_Gen(PFOTools mct, PFOTools pfot)
     Float_t pfo_p_mag = (Float_t) vt.v3().R();
     Float_t pfo_cos   = std::cos(vt.v3().Theta());
 
-    // if(abs(_pfo.pfo_pdgcheat[ipfo]) == 321) {
-    //   cout << "recoK E: " << _pfo.pfo_E[ipfo] << ", p: " << pfo_p_mag << ", px: " << _pfo.pfo_px[ipfo] << ", py: " << _pfo.pfo_py[ipfo] << ", pz: " << _pfo.pfo_pz[ipfo] << ", charge: " << _pfo.pfo_charge[ipfo] << ", ntracks: " << _pfo.pfo_ntracks[ipfo] << ", cheatID: " << _pfo.pfo_pdgcheat_id[ipfo] - 3346305 << "\n";
-    //   if(_pfo.pfo_nparents) {
-    //     cout << "         ";
-    //     for (auto iparent :  _pfo.pfo_pdgcheat_parent[ipfo]) {
-    //       if(iparent != -1000) cout << iparent << " ";
-    //     }
-    //     cout << endl;
-    //   }
-    // }
     if(abs(_pfo.pfo_pdgcheat[ipfo]) == 321 && 20 < pfo_p_mag) {
       cnt_reco_K++;
       _hm.h2[_hm.reco_K_p_cos]->Fill(pfo_cos,pfo_p_mag);
     }
   }
-
-  // if( cnt_gen_K != cnt_reco_K ) cout << "genK: " << cnt_gen_K << ", recoK: " << cnt_reco_K << endl;
 
 }
 

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -148,7 +148,7 @@ void EventAnalyzer::AnalyzeReco(Long64_t entry)
   // Base Selection (mom, tpc_hit, offset)
     Bool_t LPFO_double_quality    = true;
     for ( auto iLPFO : pfot.KLPFO ){
-      if( !pfot.PFO_Quality_checks(iLPFO) ){
+      if( !pfot.LPFO_Quality_checks(iLPFO) ){
         LPFO_double_quality = false;
         break;
       }
@@ -615,14 +615,14 @@ void EventAnalyzer::PolarAngle(PFOTools pfot, PFOTools mct, Bool_t s_reco)
       // _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * sgn( iLPFO.pfo_charge * _mc.mc_quark_charge[0] ) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
     
       if ( _mc.mc_quark_charge[0] < 0) {
-        cout << "NO" << endl;
+        // cout << "NO" << endl;
         if ( iLPFO.pfo_charge < 0 ) {
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
         }else{
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * -mct.mc_quark[1].cos / abs(mct.mc_quark[1].cos) );
         }
       }else{
-        cout << "YES " << iLPFO.pfo_charge << " " << abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) << endl;
+        // cout << "YES " << iLPFO.pfo_charge << " " << abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) << endl;
         if ( iLPFO.pfo_charge > 0 ) {
           _hm.h1[_hm.reco_K_scos]->Fill( abs(iLPFO.cos) * mct.mc_quark[0].cos / abs(mct.mc_quark[0].cos) );
         }else{

--- a/NtupleProcessor/src/EventAnalyzer.cc
+++ b/NtupleProcessor/src/EventAnalyzer.cc
@@ -433,20 +433,22 @@ Int_t *EventAnalyzer::Gen_Reco_Stats_Stable( PFOTools mct, PFOTools pfot, Float_
   Float_t p_min = _anCfg.PFO_p_min;
 
   std::vector<PFO_Info> PFO_K_Collection;
+  std::vector<PFO_Info> Gen_K_Collection;
   for ( auto iPFO : PFO_Collection ){
     Bool_t cos_range = (cos_min < iPFO.cos && iPFO.cos < cos_max );
     Bool_t p_range   = p_min < iPFO.p_mag;
-    if( PFOTools::isKaon(iPFO) && cos_range && p_range ) PFO_K_Collection.push_back(iPFO);
+    if( PFOTools::isKaon(iPFO) && cos_range && p_range )   PFO_K_Collection.push_back(iPFO);
+    if( abs(iPFO.pfo_pdgcheat) == 321 && cos_range && p_range ) Gen_K_Collection.push_back(iPFO);
   }
 
-  std::vector<MC_Info> Gen_K_Collection;
-  for ( int istable=0; istable < _mc.mc_stable_n; istable++ ){
-    Bool_t cos_range = ( cos_min < mct.mc_stable[istable].cos && mct.mc_stable[istable].cos < cos_max );
-    Bool_t p_range   = p_min < mct.mc_stable[istable].p_mag;
-    if(abs(_mc.mc_stable_pdg[istable]) == 321 && cos_range && p_range) {
-      Gen_K_Collection.push_back( mct.mc_stable[istable] );
-    }
-  }
+  // std::vector<MC_Info> Gen_K_Collection;
+  // for ( int istable=0; istable < _mc.mc_stable_n; istable++ ){
+  //   Bool_t cos_range = ( cos_min < mct.mc_stable[istable].cos && mct.mc_stable[istable].cos < cos_max );
+  //   Bool_t p_range   = p_min < mct.mc_stable[istable].p_mag;
+  //   if(abs(_mc.mc_stable_pdg[istable]) == 321 && cos_range && p_range) {
+  //     Gen_K_Collection.push_back( mct.mc_stable[istable] );
+  //   }
+  // }
 
   Int_t N_K_corr  = 0;
 

--- a/NtupleProcessor/src/PFOTools.cc
+++ b/NtupleProcessor/src/PFOTools.cc
@@ -173,11 +173,12 @@ void PFOTools::InitializePFOTools( MC_QQbar *mc_data, PFO_QQbar *data )
     PFO.dEdx_dist_pdg = Get_dEdx_dist_PID( PFO.pfo_piddedx_k_dedxdist, PFO.pfo_piddedx_pi_dedxdist, PFO.pfo_piddedx_p_dedxdist );
     PFO.cos           = std::cos(PFO.vt.v3().Theta());
 
-    if ( mc_data->mc_quark_charge[0] < 0 ){
-      PFO.qcos = (PFO.pfo_charge < 0) ? PFO.cos : -PFO.cos;
-    }else{
-      PFO.qcos = (PFO.pfo_charge > 0) ? PFO.cos : -PFO.cos;
-    }
+    PFO.qcos = (PFO.pfo_charge < 0) ? PFO.cos : -PFO.cos;
+    // if ( mc_data->mc_quark_charge[0] < 0 ){
+    //   PFO.qcos = (PFO.pfo_charge < 0) ? PFO.cos : -PFO.cos;
+    // }else{
+    //   PFO.qcos = (PFO.pfo_charge > 0) ? PFO.cos : -PFO.cos;
+    // }
 
     PFO_jet[ijet].push_back(PFO);
     

--- a/NtupleProcessor/src/PFOTools.cc
+++ b/NtupleProcessor/src/PFOTools.cc
@@ -69,6 +69,13 @@ void PFOTools::InitializePFOTools( MC_QQbar *mc_data, PFO_QQbar *data )
     // Make suer PFO has only one reconstructed track to avoid (lambda/sigma)
     if (data->pfo_ntracks[ipfo] != 1) continue;
 
+    // if dEdx dist is 0
+    if( is_dEdxdist_bad(data->pfo_piddedx_e_dedxdist[ipfo],
+                        data->pfo_piddedx_mu_dedxdist[ipfo],
+                        data->pfo_piddedx_pi_dedxdist[ipfo],
+                        data->pfo_piddedx_k_dedxdist[ipfo],
+                        data->pfo_piddedx_p_dedxdist[ipfo]) ) continue;
+
     VectorTools vt(data->pfo_px[ipfo], data->pfo_py[ipfo], data->pfo_pz[ipfo], data->pfo_E[ipfo]);
 
     // Initialize & categorize PFO variables with different jets
@@ -297,13 +304,13 @@ Bool_t PFOTools::is_charge_config( ChargeConfig cc )
 
 }
 
-Bool_t PFOTools::PFO_Quality_checks( PFO_Info iPFO )
+Bool_t PFOTools::LPFO_Quality_checks( PFO_Info iPFO )
 {
   vector<Bool_t> CutTrigger;
 
-  CutTrigger.push_back( is_momentum( iPFO, _anCfg.LPFO_p_min, _anCfg.LPFO_p_max ) );     // MIN/MAX momentum check
-  CutTrigger.push_back( is_tpc_hits( iPFO, _anCfg.PFO_TPCHits_max ) );            // Number of TPC hit check
-  CutTrigger.push_back( is_offset_small( iPFO, _anCfg.PFO_offset_max ) );        // Offset distance check
+  CutTrigger.push_back( is_momentum( iPFO, _anCfg.LPFO_p_min, _anCfg.LPFO_p_max ) );  // MIN/MAX momentum check
+  CutTrigger.push_back( is_tpc_hits( iPFO, _anCfg.PFO_TPCHits_max ) );                // Number of TPC hit check
+  CutTrigger.push_back( is_offset_small( iPFO, _anCfg.PFO_offset_max ) );             // Offset distance check
   
   for (auto trigger : CutTrigger ){
     if (!trigger) { return false; }
@@ -326,4 +333,14 @@ Bool_t PFOTools::is_tpc_hits( PFO_Info iPFO, Int_t MIN_TPC_HITS )
 Bool_t PFOTools::is_offset_small( PFO_Info iPFO, Int_t MAX_OFFSET )
 {
   return ( iPFO.pv < MAX_OFFSET );
+}
+
+Bool_t PFOTools::is_dEdxdist_bad( Float_t e_dist, Float_t mu_dist, Float_t pi_dist, Float_t k_dist, Float_t p_dist )
+{
+  if( !e_dist ) return 1;
+  if( !mu_dist ) return 1;
+  if( !pi_dist ) return 1;
+  if( !k_dist ) return 1;
+  if( !p_dist ) return 1;
+  return 0;
 }

--- a/NtupleProcessor/src/PFOTools.cc
+++ b/NtupleProcessor/src/PFOTools.cc
@@ -31,11 +31,11 @@ PFOTools::PFOTools( MC_QQbar *ptr, TString fnac )
     InitializeMCTools( mc_data );
 }
 
-PFOTools::PFOTools( PFO_QQbar *ptr, TString fnac )
-: data(ptr)
+PFOTools::PFOTools( MC_QQbar *ptr_mc, PFO_QQbar *ptr, TString fnac )
+: mc_data(ptr_mc), data(ptr)
 {
     _anCfg.SetConfig(fnac);
-    InitializePFOTools( data );
+    InitializePFOTools( mc_data, data );
 }
 
 void PFOTools::InitializeMCTools( MC_QQbar *mc_data )
@@ -58,7 +58,7 @@ void PFOTools::InitializeMCTools( MC_QQbar *mc_data )
 }
 
 
-void PFOTools::InitializePFOTools( PFO_QQbar *data )
+void PFOTools::InitializePFOTools( MC_QQbar *mc_data, PFO_QQbar *data )
 {
 
   for (int ipfo=0; ipfo < data->pfo_n; ipfo++)
@@ -165,7 +165,12 @@ void PFOTools::InitializePFOTools( PFO_QQbar *data )
 
     PFO.dEdx_dist_pdg = Get_dEdx_dist_PID( PFO.pfo_piddedx_k_dedxdist, PFO.pfo_piddedx_pi_dedxdist, PFO.pfo_piddedx_p_dedxdist );
     PFO.cos           = std::cos(PFO.vt.v3().Theta());
-    PFO.qcos          = (PFO.pfo_charge < 0) ? PFO.cos : -PFO.cos;
+
+    if ( mc_data->mc_quark_charge[0] < 0 ){
+      PFO.qcos = (PFO.pfo_charge < 0) ? PFO.cos : -PFO.cos;
+    }else{
+      PFO.qcos = (PFO.pfo_charge > 0) ? PFO.cos : -PFO.cos;
+    }
 
     PFO_jet[ijet].push_back(PFO);
     


### PR DESCRIPTION
The definition of the gen kaon was changed from mc_stables in the generator information to the pfo_pdgcheat contained inside the PFO information. This is because mc_stable sometimes misses the kaons they're supposed to be returning, e.g., kaons radiating a photon after the Bremsstrahlung. 
Thus switching the variable from mc_stable to pfo_pdgcheat was necessary. The branch was created to check the outcome after this change, and we now confirm the result is consistent with the one before the change.