### PR TITLE
Change binning

### DIFF
--- a/NtupleProcessor/include/EventAnalyzer.hh
+++ b/NtupleProcessor/include/EventAnalyzer.hh
@@ -64,7 +64,7 @@ class EventAnalyzer
   // Histogram extractor
     void             PolarAngleGen(PFOTools mct);
     void             Mom_Polar_Gen(PFOTools mct,PFOTools pfot);
-    void             PolarAngle(PFOTools pfot, PFOTools mct, Bool_t s_reco);
+    void             PolarAngle(PFOTools pfot, PFOTools mct, vector<Bool_t> cuts, Int_t double_tag);
     void             PolarAngle_acc_rej(PFOTools pfot, vector<Bool_t> cuts, Bool_t ss_config);
 
     void             Jet_sum_n_acol();

--- a/NtupleProcessor/include/PFOTools.hh
+++ b/NtupleProcessor/include/PFOTools.hh
@@ -41,7 +41,7 @@ class PFOTools
     static  Bool_t            isProton          ( PFO_Info iPFO );
 
   // LPFO checks
-    virtual Bool_t           is_charge_config ( ChargeConfig cc );
+    virtual Bool_t           is_charge_config ( ChargeConfig cc, Int_t charge0, Int_t charge1 );
 
     virtual Bool_t           LPFO_Quality_checks    ( PFO_Info iPFO );
     virtual Bool_t           is_momentum           ( PFO_Info iPFO, Float_t MINP, Float_t MAXP );

--- a/NtupleProcessor/src/HistManager.cc
+++ b/NtupleProcessor/src/HistManager.cc
@@ -29,18 +29,18 @@ void HistManager::InitializeHists()
   //////////////////
   //     TH1F     //
   //////////////////
-    h1[gen_q_cos]       = new TH1F("h_gen_q_cos","; Generated q#bar{q} cos#theta; Entries",nbins_cos,bins_cos_fine);
-    h1[gen_q_qcos]      = new TH1F("h_gen_q_qcos","; Generated q#bar{q} qcos#theta; Entries",nbins_cos,bins_cos_fine);
+    h1[gen_q_cos]       = new TH1F("h_gen_q_cos","; Generated q#bar{q} cos#theta; Entries",cos_bin,-1,1);
+    h1[gen_q_qcos]      = new TH1F("h_gen_q_qcos","; Generated q#bar{q} qcos#theta; Entries",cos_bin,-1,1);
 
-    h1[gen_K_cos]       = new TH1F("h_gen_K_cos","; Generated Kaon cos#theta; Entries",nbins_cos,bins_cos_fine);
-    h1[gen_K_qcos]      = new TH1F("h_gen_K_qcos","; Generated Kaon qcos#theta; Entries",nbins_cos,bins_cos_fine);
+    h1[gen_K_cos]       = new TH1F("h_gen_K_cos","; Generated Kaon cos#theta; Entries",cos_bin,-1,1);
+    h1[gen_K_qcos]      = new TH1F("h_gen_K_qcos","; Generated Kaon qcos#theta; Entries",cos_bin,-1,1);
     
-    h1[reco_K_cos]      = new TH1F("h_reco_K_cos",";LPFO Kaon cos#theta; Entries",nbins_cos,bins_cos_fine);
-    h1[reco_K_qcos]     = new TH1F("h_reco_K_qcos",";LPFO Kaon cos#theta; Entries",nbins_cos,bins_cos_fine);
+    h1[reco_K_cos]      = new TH1F("h_reco_K_cos",";LPFO Kaon cos#theta; Entries",cos_bin,-1,1);
+    h1[reco_K_qcos]     = new TH1F("h_reco_K_qcos",";LPFO Kaon cos#theta; Entries",cos_bin,-1,1);
     
-    h1[reco_K_scos]     = new TH1F("h_reco_K_scos",";LPFO Kaon cos#theta; Entries",nbins_cos,bins_cos_fine);
+    h1[reco_K_scos]     = new TH1F("h_reco_K_scos",";LPFO Kaon cos#theta; Entries",cos_bin,-1,1);
 
-    h1[gen_reco_K_sep_cos] = new TH1F("h_gen_reco_K_sep_cos",";Kaon cos#theta_{gen-reco}; Entries",nbins_cos,bins_cos_fine);
+    h1[gen_reco_K_sep_cos] = new TH1F("h_gen_reco_K_sep_cos",";Kaon cos#theta_{gen-reco}; Entries",cos_bin,-1,1);
 
   // ISR parameters
     h1[reco_sum_jetE]   = new TH1F("h_reco_sum_jetE", ";Visible Energy (GeV);", 100, 0, 300);
@@ -50,17 +50,17 @@ void HistManager::InitializeHists()
     h1[lpfo_reco_K_mom] = new TH1F("h_lpfo_reco_K_mom","; Leading Reco Kaon momentum (GeV); Entries",100,0,100);
 
   // Number of Gen Reco Kaons
-    h1[gen_N_K_cos]     = new TH1F("h_gen_N_K_cos",";cos#theta;Generated N Kaons", nbins_cos,bins_cos_fine);
-    h1[reco_N_K_cos]    = new TH1F("h_reco_N_K_cos",";cos#theta;Reconstructed N Kaons", nbins_cos,bins_cos_fine);
-    h1[N_K_corr_cos]    = new TH1F("h_N_K_corr_cos",";cos#theta;Correctly Reconstructed N Kaons", nbins_cos,bins_cos_fine);
+    h1[gen_N_K_cos]     = new TH1F("h_gen_N_K_cos",";cos#theta;Generated N Kaons", cos_bin,-1,1);
+    h1[reco_N_K_cos]    = new TH1F("h_reco_N_K_cos",";cos#theta;Reconstructed N Kaons", cos_bin,-1,1);
+    h1[N_K_corr_cos]    = new TH1F("h_N_K_corr_cos",";cos#theta;Correctly Reconstructed N Kaons", cos_bin,-1,1);
 
     h1[gen_N_K_cos2]    = new TH1F("h_gen_N_K_cos2",";cos#theta;Generated N Kaons", 100,-1,1);
     h1[reco_N_K_cos2]   = new TH1F("h_reco_N_K_cos2",";cos#theta;Reconstructed N Kaons", 100,-1,1);
     h1[N_K_corr_cos2]   = new TH1F("h_N_K_corr_cos2",";cos#theta;Correctly Reconstructed N Kaons", 100,-1,1);
 
   // pq method
-    h1_pq[acc_KK]      = new TH1F("h_acc_KK_cos",";Accepted K^{+}K^{-} cos#theta;N_{acc}",nbins_cos,bins_cos_fine);
-    h1_pq[rej_KK]      = new TH1F("h_rej_KK_cos",";Rejected K^{+}K^{-} cos#theta;N_{rej}",nbins_cos,bins_cos_fine);
+    h1_pq[acc_KK]      = new TH1F("h_acc_KK_cos",";Accepted K^{+}K^{-} cos#theta;N_{acc}",cos_bin,-1,1);
+    h1_pq[rej_KK]      = new TH1F("h_rej_KK_cos",";Rejected K^{+}K^{-} cos#theta;N_{rej}",cos_bin,-1,1);
 
   // particle ratio
     h1_particle_ratio[K_rate_gen]  = new TH1F("h_K_rate_gen",";Ratio of Kaons / Event (gen);Entries",11,0,1.1);

--- a/NtupleProcessor/src/PFOTools.cc
+++ b/NtupleProcessor/src/PFOTools.cc
@@ -281,10 +281,11 @@ Bool_t PFOTools::isProton( PFO_Info iPFO )
     return iPFO.dEdx_dist_pdg == 2212;
 }
 
-Bool_t PFOTools::is_charge_config( ChargeConfig cc )
+Bool_t PFOTools::is_charge_config( ChargeConfig cc, Int_t charge0 , Int_t charge1 )
 {
 
-  Int_t charge_config = LPFO[0].pfo_charge * LPFO[1].pfo_charge;
+  // Int_t charge_config = LPFO[0].pfo_charge * LPFO[1].pfo_charge;
+  Int_t charge_config = charge0 * charge1;
 
   switch (cc)
   {

--- a/macros/Stability_Purity.cc
+++ b/macros/Stability_Purity.cc
@@ -36,8 +36,8 @@ void Stability_Purity()
   gStyle->SetOptStat(0);
   gStyle->SetPadBorderSize(1);
 
-  // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.uu.LPFOp15_pNaN.tpc0.hists.all.root","READ");
-  TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.ss.LPFOp15_pNaN.tpc0.hists.all.root","READ");
+  TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.uu.LPFOp15_pNaN.tpc0.hists.all.root","READ");
+  // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.ss.LPFOp15_pNaN.tpc0.hists.all.root","READ");
   // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.dd.LPFOp15_pNaN.tpc0.hists.all.root","READ");
 
   TTree *t_data = (TTree*) file->Get("data");

--- a/macros/p_visual.cc
+++ b/macros/p_visual.cc
@@ -1,0 +1,53 @@
+#include <iostream>
+
+template <class P1>
+void StylePad(P1 *pad, Float_t t, Float_t b, Float_t r, Float_t l)
+{
+  pad->SetGrid(1,1);
+  if(t) pad->SetTopMargin(t);
+  if(b) pad->SetBottomMargin(b);
+  if(r) pad->SetRightMargin(r);
+  if(l) pad->SetLeftMargin(l);
+  pad->Draw();
+  pad->cd();
+
+}
+
+Double_t func(Double_t *val, Double_t *par)
+{
+  Float_t accepted = val[1];
+  Float_t rejected = val[0];
+  Double_t a = 1;
+  Double_t b = -1;
+  Double_t c = rejected / (2 * (accepted + rejected));
+  Double_t p = (0.5 / a) * (-b + sqrt(b * b - 4 * a * c));
+
+  return p;
+}
+
+Double_t line(Double_t *val, Double_t *par)
+{
+  Float_t  x = val[0];
+  Double_t y = 109.0*x / 91.0;
+
+  return y;
+}
+
+void p_visual()
+{
+  gStyle->SetOptStat(0);
+  TGaxis::SetMaxDigits(3);
+  TCanvas *c0 = new TCanvas("c1","c1",800,800);
+  gPad->SetGrid(1,1);
+  StylePad(gPad,0,0,0.17,0.1);
+
+  auto f   = new TF2("f",func,4000,21000,4000,21000);
+  auto lin = new TF2("f",line,4000,21000,4000,21000);
+  f->SetTitle(";Rejected;Accepted;p value");
+  f->GetZaxis()->SetTitleOffset(1.5);
+  f->Draw("colz");
+  // f->Draw("surf2");
+  // lin->Draw("surf2");
+
+
+}

--- a/macros/p_visual.cc
+++ b/macros/p_visual.cc
@@ -41,13 +41,27 @@ void p_visual()
   gPad->SetGrid(1,1);
   StylePad(gPad,0,0,0.17,0.1);
 
-  auto f   = new TF2("f",func,4000,21000,4000,21000);
-  auto lin = new TF2("f",line,4000,21000,4000,21000);
+  Float_t alow  = 4E3;
+  Float_t ahigh = 35E3;
+
+  auto f   = new TF2("f",func,alow,ahigh,alow,ahigh);
+  auto f2 = new TF2("f2",func,alow,ahigh,alow,ahigh);
   f->SetTitle(";Rejected;Accepted;p value");
   f->GetZaxis()->SetTitleOffset(1.5);
   f->Draw("colz");
-  // f->Draw("surf2");
-  // lin->Draw("surf2");
+  
+  // f2->GetZaxis()->SetRangeUser(0.5,0.6);
+  f2->SetContour(10);
+  f2->Draw("CONT2 same");
+
+  Float_t accepted = 20E3;
+  Float_t rejected = 21.5E3;
+  Double_t a = 1;
+  Double_t b = -1;
+  Double_t c = rejected / (2 * (accepted + rejected));
+  Double_t p = (0.5 / a) * (-b + sqrt(b * b - 4 * a * c));
+  cout << p << endl;
+
 
 
 }

--- a/macros/pq_method.cc
+++ b/macros/pq_method.cc
@@ -305,7 +305,7 @@ void main_pq()
   f_reco->SetParNames("S","A");
   h_reco_K_pq_cos->Fit("f_reco","MNRS");
 
-  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,73E3);
+  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,30E3);
   h_reco_K_pq_cos->SetTitle(";K^{+}K^{-} cos#theta;a.u.");
   h_reco_K_pq_cos->Draw("h");
   h_reco_K_qcos_eff_corr->Draw("hsame");
@@ -336,7 +336,7 @@ void main_pq()
   gPad->SetGrid(1,1);
   h_acc_KK_cos_eff_corr->SetTitle(";K^{+}K^{-} cos#theta;Entries");
 
-  h_acc_KK_cos_eff_corr->GetYaxis()->SetRangeUser(0,40E3);
+  h_acc_KK_cos_eff_corr->GetYaxis()->SetRangeUser(0,30E3);
   h_acc_KK_cos_eff_corr->Draw("h");
   h_rej_KK_cos_eff_corr->Draw("hsame");
 

--- a/macros/pq_method.cc
+++ b/macros/pq_method.cc
@@ -68,6 +68,9 @@ vector<Float_t> GetP( TH1F * h_accepted, TH1F * h_rejected )
 
   for (int i = 1; i < nbins / 2 + 1; i++)
   {
+
+    cout << "=== " << i << " (" << nbins + 1 - i << ") ===" << endl;
+
     std::vector<float> result_j;
     for (int i1 = -1; i1 < 2; i1 += 2)
     {
@@ -84,6 +87,11 @@ vector<Float_t> GetP( TH1F * h_accepted, TH1F * h_rejected )
           float c = rejected / (2 * (accepted + rejected));
           float p = (0.5 / a) * (-b + sqrt(b * b - 4 * a * c));
           float p2 = (0.5 / a) * (-b - sqrt(b * b - 4 * a * c));
+
+          cout << "i1=" << i1 << ",i2=" << i2 << ",i3=" << i3 << endl;
+          cout << "acc binc: " << h_accepted->GetBinContent(nbins + 1 - i) << ", rej binc: " << h_rejected->GetBinContent(nbins + 1 - i) << endl;
+          cout << "acc: " << accepted << ", rej: " << rejected << ", p = " << p << ", p2 = " << p2 << endl;
+
           if (p > 0.99)
             p = 0;
           if (p2 > 0.99)
@@ -143,11 +151,12 @@ TH1F * CorrectHist( TH1F * h_reco, vector<Float_t> p_vec)
 {
   const Int_t nbins = h_reco->GetNbinsX();
 
-  TH1F *corrected = new TH1F("corrected", "corrected", nbins_cos,bins_cos_fine);
+  TH1F *corrected = new TH1F("corrected", "corrected", 100,-1,1);
   corrected->Sumw2();
   for (int i = 1; i < nbins / 2 + 1; i++)
   {
     float p = p_vec.at(i - 1);
+    // float p = 0.65;
     float q = 1 - p;
     float weight = (p * p + q * q) / (q * q * q * q - p * p * p * p);
 
@@ -170,6 +179,7 @@ TH1F * CorrectHist( TH1F * h_reco, vector<Float_t> p_vec)
     av_41i /= n;
     corrected->SetBinContent(i, av_i);
     corrected->SetBinContent(nbins + 1 - i, av_41i);
+    // cout << "val: " << av_41i << ", p: " << p << endl;
 
     // calculate error
     float error_i = 0;
@@ -208,7 +218,7 @@ TH1F * Efficiency_Correction( TH1F * h, TString name, TFile * file )
   if( h->GetNbinsX() != h_stable_cos->GetNbinsX() ) throw std::logic_error("Error");
 
   Int_t nbins = h_stable_cos->GetNbinsX();
-  TH1F *corrected = new TH1F(name.Data(), "corrected", nbins_cos,bins_cos_fine);
+  TH1F *corrected = new TH1F(name.Data(), "corrected", 100,-1,1);
   corrected->Sumw2();
   for (int ibin = 1; ibin < nbins + 1; ibin++){
 
@@ -227,8 +237,8 @@ void main_pq()
 {
   gStyle->SetOptStat(0);
 
-  // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.uu.LPFOp15_pNaN.tpc0.hists.all.root","READ");
-  TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.ss.LPFOp15_pNaN.tpc0.hists.all.root","READ");
+  TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.uu.LPFOp15_pNaN.tpc0.hists.all.root","READ");
+  // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.ss.LPFOp15_pNaN.tpc0.hists.all.root","READ");
   // TFile *file = new TFile("../rootfiles/merged/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.ss.LPFOp20_p60.tpc0.hists.all.root","READ");
 
   if (!file->IsOpen()) return;
@@ -262,7 +272,7 @@ void main_pq()
 
   const Int_t nbins = h_reco_K_scos_eff_corr->GetNbinsX();
 
-  TH1F *p_KK = new TH1F("p_KK", "p_KK", nbins_cos_half,bins_cos_fine_half);
+  TH1F *p_KK = new TH1F("p_KK", "p_KK", 50,0,1);
   p_KK->Sumw2();
 
   vector<Float_t> p_vec = GetP(h_acc_KK_cos_eff_corr, h_rej_KK_cos_eff_corr);
@@ -280,22 +290,22 @@ void main_pq()
   TPad *pad0 = new TPad("pad0", "pad0",0,0,1,1);
   StylePad(pad0,0,0.12,0,0.15);
 
-  BinNormal(h_gen_q_qcos);
-  BinNormal(h_reco_K_scos_eff_corr);
-  BinNormal(h_reco_K_pq_cos);
-  BinNormal(h_reco_K_qcos_eff_corr);
+  // BinNormal(h_gen_q_qcos);
+  // BinNormal(h_reco_K_scos_eff_corr);
+  // BinNormal(h_reco_K_pq_cos);
+  // BinNormal(h_reco_K_qcos_eff_corr);
 
-  Normalize(h_gen_q_qcos);
-  Normalize(h_reco_K_scos_eff_corr);
-  Normalize(h_reco_K_pq_cos);
-  Normalize(h_reco_K_qcos_eff_corr);
+  Normalize2Gen(h_gen_q_qcos,h_reco_K_scos_eff_corr);
+  // Normalize(h_reco_K_scos_eff_corr);
+  // Normalize(h_reco_K_pq_cos);
+  // Normalize(h_reco_K_qcos_eff_corr);
 
   // Fitting
   TF1 * f_reco = new TF1("f_reco","[0]*(1+x*x)+[1]*x",-0.8,0.8);
   f_reco->SetParNames("S","A");
   h_reco_K_pq_cos->Fit("f_reco","MNRS");
 
-  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,0.20);
+  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,73E3);
   h_reco_K_pq_cos->SetTitle(";K^{+}K^{-} cos#theta;a.u.");
   h_reco_K_pq_cos->Draw("h");
   h_reco_K_qcos_eff_corr->Draw("hsame");
@@ -306,8 +316,8 @@ void main_pq()
 
   TLegend *leg = new TLegend(0.2,0.76,0.7,0.85);
   leg->SetLineColor(0);
-  leg->AddEntry(h_gen_q_qcos,"Generated u-quark angle","l");
-  leg->AddEntry(h_reco_K_scos_eff_corr,"Reconstructed K^{+}K^{-} matched with u-quark angle","l");
+  leg->AddEntry(h_gen_q_qcos,"Generated s-quark angle","l");
+  leg->AddEntry(h_reco_K_scos_eff_corr,"Reconstructed K^{+}K^{-} matched with s-quark angle","l");
   leg->AddEntry(h_reco_K_qcos_eff_corr,"Reconstructed K^{+}K^{-}","l");
   leg->AddEntry(h_reco_K_pq_cos,"Reconstructed K^{+}K^{-} (corrected)","l");
   leg->Draw();
@@ -326,17 +336,32 @@ void main_pq()
   gPad->SetGrid(1,1);
   h_acc_KK_cos_eff_corr->SetTitle(";K^{+}K^{-} cos#theta;Entries");
 
-  BinNormal(h_acc_KK_cos_eff_corr);
-  BinNormal(h_rej_KK_cos_eff_corr);
-
+  h_acc_KK_cos_eff_corr->GetYaxis()->SetRangeUser(0,40E3);
   h_acc_KK_cos_eff_corr->Draw("h");
   h_rej_KK_cos_eff_corr->Draw("hsame");
+
+  TH1F * acc_full = (TH1F*) h_acc_KK_cos_eff_corr->Clone();
+  TH1F * acc_add  = new TH1F("acc_add","acc_add",nbins,-1,1);
+
+  for (int i = 1; i < nbins / 2 + 1; i++)
+  {
+    float accepted = acc_full->GetBinContent(nbins + 1 - i);
+    accepted += acc_full->GetBinContent(i);
+    acc_add->SetBinContent(i,accepted);
+    acc_add->SetBinContent(nbins+1-i,accepted);
+  }
+  StyleHist(acc_add,kRed);
+  acc_add->Draw("hsame");
 
   TLegend *leg2 = new TLegend(0.15,0.75,0.45,0.85);
   leg2->SetLineColor(0);
   leg2->AddEntry(h_acc_KK_cos_eff_corr,"N Accepted","l");
   leg2->AddEntry(h_rej_KK_cos_eff_corr,"N Rejected","l");
+  leg2->AddEntry(acc_add,"N Accepted + opp. bin","l");
   leg2->Draw();
+
+
+
 
 }
 

--- a/macros/pq_method_BGFit.cc
+++ b/macros/pq_method_BGFit.cc
@@ -429,7 +429,7 @@ void main_pq_BGFit( TFile *files[] )
   h_reco_K_pq_cos_subtracted_back->Draw("hsame");
 
   // -0.4 < cos
-  TF1 * f_uu_back = new TF1("f_uu_back","[0]*(1+x*x)+[1]*x",-0.6,-0.1);
+  TF1 * f_uu_back = new TF1("f_uu_back","[0]*(1+x*x)+[1]*x",-0.4,-0.1);
   TF1 * f_uu_full = new TF1("f_uu_full","[0]*(1+x*x)+[1]*x",-1.0,1.0);
 
   f_uu_back->SetParNames("S","A");

--- a/macros/pq_method_BGFit.cc
+++ b/macros/pq_method_BGFit.cc
@@ -6,7 +6,8 @@ using std::vector;
 
 Float_t bins_cos_fine[] = {-1.0,-0.98,-0.96,-0.94,-0.92,-0.90,-0.88,-0.86,-0.84,-0.82,-0.80,-0.75,-0.70,-0.60,-0.50,-0.40,-0.30,-0.20,-0.10,
                             0.0,0.10,0.20,0.30,0.40,0.50,0.60,0.70,0.75,0.80,0.82,0.84,0.86,0.88,0.90,0.92,0.94,0.96,0.98,1.0};
-Int_t   nbins_cos = sizeof(bins_cos_fine) / sizeof(Float_t) - 1;
+// Int_t   nbins_cos = sizeof(bins_cos_fine) / sizeof(Float_t) - 1;
+Int_t   nbins_cos = 100;
 
 Float_t bins_cos_fine_half[] = {0.0,0.10,0.20,0.30,0.40,0.50,0.60,0.70,0.75,0.80,0.82,0.84,0.86,0.88,0.90,0.92,0.94,0.96,0.98,1.0};
 Int_t   nbins_cos_half = sizeof(bins_cos_fine_half) / sizeof(Float_t) - 1;
@@ -166,7 +167,7 @@ TH1F * CorrectHist( TH1F * h_reco, vector<Float_t> p_vec)
 {
   const Int_t nbins = h_reco->GetNbinsX();
 
-  TH1F *corrected = new TH1F("corrected", "corrected", nbins_cos,bins_cos_fine);
+  TH1F *corrected = new TH1F("corrected", "corrected", 100,-1,1);
   corrected->Sumw2();
   for (int i = 1; i < nbins / 2 + 1; i++)
   {
@@ -231,7 +232,7 @@ TH1F * Efficiency_Correction( TH1F * h, TString name, TFile * file )
   if( h->GetNbinsX() != h_stable_cos->GetNbinsX() ) throw std::logic_error("Error");
 
   Int_t nbins = h_stable_cos->GetNbinsX();
-  TH1F *corrected = new TH1F(name.Data(), "corrected", nbins_cos,bins_cos_fine);
+  TH1F *corrected = new TH1F(name.Data(), "corrected", 100,-1,1);
   corrected->Sumw2();
   for (int ibin = 1; ibin < nbins + 1; ibin++){
 
@@ -340,7 +341,7 @@ void main_pq_BGFit( TFile *files[] )
 
   const Int_t nbins = h_reco_us_K_scos_eff_corr->GetNbinsX();
 
-  TH1F *p_KK = new TH1F("p_KK", "p_KK", nbins_cos_half,bins_cos_fine_half);
+  TH1F *p_KK = new TH1F("p_KK", "p_KK", 50,0,1);
   p_KK->Sumw2();
 
   vector<Float_t> p_vec = GetP(h_acc_KK_cos_eff_corr, h_rej_KK_cos_eff_corr);
@@ -387,7 +388,7 @@ void main_pq_BGFit( TFile *files[] )
   f_ss_full->SetParameters(ss_par);
 
   // function to histogram
-  TH1F * h_f_ss_full = new TH1F("h_f_ss_full", "h_f_ss_full", nbins_cos,bins_cos_fine);
+  TH1F * h_f_ss_full = new TH1F("h_f_ss_full", "h_f_ss_full", 100,-1,1);
   Func2Hist(h_f_ss_full,ss_par);
 
   TH1F* h_reco_K_pq_cos_subtracted_back = (TH1F*) h_reco_K_pq_cos->Clone();
@@ -442,7 +443,7 @@ void main_pq_BGFit( TFile *files[] )
   f_uu_full->Draw("same");
 
 
-  TH1F * h_f_uu_full = new TH1F("h_f_uu_full", "h_f_uu_full", nbins_cos,bins_cos_fine);
+  TH1F * h_f_uu_full = new TH1F("h_f_uu_full", "h_f_uu_full", 100,-1,1);
   Func2Hist(h_f_uu_full,uu_par);
 
 

--- a/macros/pq_method_BGFit.cc
+++ b/macros/pq_method_BGFit.cc
@@ -57,11 +57,11 @@ void NormalizeGen(TH1F *h, Float_t norm_top)
   h->Scale( norm_top / h->GetEntries() );
 }
 
-void Normalize2Gen(TH1F *h, TH1F *h_gen)
+void Normalize2Reco(TH1F *h_reco, TH1F *h_gen)
 {
-	double intCosReco = h->Integral(20,80);
+	double intCosReco = h_reco->Integral(20,80);
 	double intCosGen  = h_gen->Integral(20,80);
-  h->Scale( intCosGen / intCosReco );
+  h_gen->Scale( intCosReco / intCosGen );
 }
 
 void StyleHist(TH1F *h, Color_t col)
@@ -272,10 +272,9 @@ void main_pq_BGFit( TFile *files[] )
   StyleHist(h_gen_ss_qcos,kBlack);
   h_gen_ss_qcos->SetFillStyle(0);
   h_gen_ss_qcos->SetLineStyle(2);
-  BinNormal(h_gen_ss_qcos);
 
-  Normalize(h_gen_uu_qcos,1.0);
-  Normalize(h_gen_ss_qcos,1.0);
+  // Normalize(h_gen_uu_qcos,1.0);
+  // Normalize(h_gen_ss_qcos,1.0);
 
   // reco uu/ss polar
   TH1F *h_reco_uu_K_qcos = (TH1F*) files[kUU]->Get("h_reco_K_qcos");
@@ -301,21 +300,17 @@ void main_pq_BGFit( TFile *files[] )
   StyleHist(h_gen_us_qcos,kGreen+1);
   h_gen_us_qcos->SetFillStyle(0);
   h_gen_us_qcos->SetLineStyle(2);
-  BinNormal(h_gen_us_qcos);
-
 
   StyleHist(h_gen_uu_qcos_scale,kOrange+7);
   h_gen_uu_qcos_scale->SetFillStyle(0);
   h_gen_uu_qcos_scale->SetLineStyle(2);
-  BinNormal(h_gen_uu_qcos_scale);
   // Normalize(h_gen_uu_qcos_scale,1.0);
   h_gen_uu_qcos_scale->Scale(1.0 / (Float_t) (h_gen_uu_qcos_scale->Integral()) );
 
   StyleHist(h_gen_ss_qcos_scale,kBlack);
   h_gen_ss_qcos_scale->SetFillStyle(0);
   h_gen_ss_qcos_scale->SetLineStyle(2);
-  BinNormal(h_gen_ss_qcos_scale);
-  Normalize(h_gen_ss_qcos_scale,1.0);
+  // Normalize(h_gen_ss_qcos_scale,1.0);
 
 
   // reco us polar
@@ -355,15 +350,10 @@ void main_pq_BGFit( TFile *files[] )
   TH1F *h_reco_K_pq_cos = CorrectHist(h_reco_us_K_qcos_eff_corr, p_vec);
   StyleHist(h_reco_K_pq_cos,kBlue);
 
-
-  BinNormal(h_reco_us_K_scos_eff_corr);
-  BinNormal(h_reco_K_pq_cos);
-  BinNormal(h_reco_us_K_qcos_eff_corr);
-
-  Normalize(h_gen_us_qcos, 1.0);
-  Normalize(h_reco_us_K_scos_eff_corr,1.0);
-  Normalize(h_reco_K_pq_cos,1.0);
-  Normalize(h_reco_us_K_qcos_eff_corr,1.0);
+  // Normalize(h_gen_us_qcos, 1.0);
+  // Normalize(h_reco_us_K_scos_eff_corr,1.0);
+  // Normalize(h_reco_K_pq_cos,1.0);
+  // Normalize(h_reco_us_K_qcos_eff_corr,1.0);
 
 
 
@@ -374,7 +364,7 @@ void main_pq_BGFit( TFile *files[] )
   // cos < -0.4
   Float_t split_pt = -0.4;
 
-  TF1 * f_ss_front = new TF1("f_ss_front","[0]*(1+x*x)+[1]*x",0.651,0.9);
+  TF1 * f_ss_front = new TF1("f_ss_front","[0]*(1+x*x)+[1]*x",0.0,0.8);
   TF1 * f_ss_full  = new TF1("f_ss_full","[0]*(1+x*x)+[1]*x",-1.0,1.0);
 
   f_ss_front->SetParNames("S","A");
@@ -429,7 +419,7 @@ void main_pq_BGFit( TFile *files[] )
   h_reco_K_pq_cos_subtracted_back->Draw("hsame");
 
   // -0.4 < cos
-  TF1 * f_uu_back = new TF1("f_uu_back","[0]*(1+x*x)+[1]*x",-0.4,-0.1);
+  TF1 * f_uu_back = new TF1("f_uu_back","[0]*(1+x*x)+[1]*x",-0.7,-0.3);
   TF1 * f_uu_full = new TF1("f_uu_full","[0]*(1+x*x)+[1]*x",-1.0,1.0);
 
   f_uu_back->SetParNames("S","A");
@@ -466,18 +456,26 @@ void main_pq_BGFit( TFile *files[] )
 
 
 
-  Normalize(h_reco_K_pq_cos_remain_front,1.0);
+  // Normalize(h_reco_K_pq_cos_remain_front,1.0);
 
   // Int_t scale_sum = h_gen_uu_qcos_scale->GetEntries();
   // h_gen_uu_qcos_scale->Scale( 1.8 / (Float_t) scale_sum );
 
+  // Normalize2Reco(h_gen_us_qcos,h_gen_ss_qcos_scale);
+  double intgen  = h_gen_us_qcos->Integral(50,90);
+  double intreco = h_reco_us_K_scos_eff_corr->Integral(50,90);
+  h_gen_us_qcos->Scale(intreco/intgen);
+
+  double intgen2  = h_gen_ss_qcos_scale->Integral(90,95);
+  double intreco2 = h_gen_us_qcos->Integral(90,95);
+  h_gen_ss_qcos_scale->Scale(intreco2/intgen2);
 
 
   TCanvas *c0 = new TCanvas("c0","c0",800,800);
   TPad *pad0 = new TPad("pad0", "pad0",0,0,1,1);
   StylePad(pad0,0,0.12,0,0.15);
 
-  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,0.11);
+  h_reco_K_pq_cos->GetYaxis()->SetRangeUser(0,50E3);
   h_reco_K_pq_cos->SetTitle(";K^{+}K^{-} cos#theta;a.u.");
   h_reco_K_pq_cos->Draw("h");
   h_reco_us_K_qcos_eff_corr->Draw("hsame");


### PR DESCRIPTION
## Description
 - binning has been changed
 - huge bug in sign comparison

## Context

As Adrian correctly pointed out, the numbers on two histograms were different when they should've been the same.
Some numbers before and after the p value calculation didn't match up with the histogram.

## Cause

The main cause for this problem was the inability to choose KLPFOs with opposite signs since I was referring the wrong PFO for the charge comparison. (The other information was correct, just 'charge')
There were 2 bugs that was causing this problem.

 1. One of the boolean failed to filter (it was always 1) the event, which caused reconstructed K spectra and accepted event spectra filled differently.
 2. In the code, I use objects called LPFO and KLPFO. KLPFO is the object inherited from the LPFO and they essentially contain the same information, while KLPFO has KID info in addition. Charge comparison was done using the LPFO info, thinking that these contain the same info. In reality, KLPFO is selected amongst the Kaon list, thus KLPFO is not necessarily the LPFO. KLPFO used to be chosen from the LPFO (until around October 2022) thus this bug happened when changing the KLPFO selection method.

The problem was not apparent in ssbar process since most of KLPFO "DID" correspond to LPFO, while not for uubar.
The problem could not be seen in the first few samples thus it passed the test runs. (test runs were not done for uubar samples)

## Outcome After the Fix

After the fix p values for ss got raised from 7.5 to 8.4, while it remained the same for uu.
The migration effect in uubar sample is still there.